### PR TITLE
🐛 Remove trailing comma for older chrome

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -66,7 +66,7 @@ module.exports = async function renderTextToDataURL({ text, size }) {
     copyCtx.putImageData(
       trimmed,
       (max - trimmed.width) / 2,
-      (max - trimmed.height) / 2,
+      (max - trimmed.height) / 2
     )
 
     return copy


### PR DESCRIPTION
Fix #8