### PR TITLE
Add minimum option to reduce .ico file size

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,6 +31,7 @@ Usage:
 Options:
   -d, --destination <value>  favicon destination     [default: "./favicon.ico"]
   -e, --emoji <value>        choose emoji            [default: "✨"]
+  -m, --minimum              create favicon with selected sizes (16x16, 32x32, 48x48)
   -h, --help                 Output usage information
   -l, --list                 show list of available emojis
   -p, --png <value>          png output path         [default: "./favicon.png"]
@@ -49,16 +50,17 @@ if (args['--emoji'] && args['--destination']) {
   const dest = path.resolve(args['--destination'])
   const pngDest = path.resolve(args['--png'])
   const emoji = findEmoji(args['--emoji'])
+  const sizes = args['--minimum'] ? [16, 32, 48] : [16, 32, 48, 64, 128, 256]
 
   const start = Date.now()
   const hrstart = process.hrtime()
   Promise.resolve(emoji)
-    .then(char => render(char, [16, 32, 48, 64, 128, 256]))
+    .then(char => render(char, sizes))
     .then(images => {
-      if (pngDest) fs.writeFileSync(pngDest, images[5])
+      if (pngDest) fs.writeFileSync(pngDest, images[images.length - 1])
       return images
     })
-    .then(images => toIco(images))
+    .then(images => toIco(images, {sizes}))
     .then(buf => fs.writeFileSync(dest, buf))
     .then(() => {
       const end = Date.now() - start

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ favicon-emoji --help
   Options:
     -d, --destination <value>  favicon destination     [default: "./favicon.ico"]
     -e, --emoji <value>        choose emoji            [default: "✨"]
+    -m, --minimum              create favicon with selected sizes (16x16, 32x32, 48x48)
     -h, --help                 Output usage information
     -l, --list                 show list of available emojis
     -p, --png <value>          png output path         [default: "./favicon.png"]


### PR DESCRIPTION
Is `.ico` file which includes 64x, 128x, 256x images too heavy?

In many case, `.ico` which includes only 16x, 32x, 48x is fine, I think. `--minimum` option is for it.

![before](https://user-images.githubusercontent.com/1800018/33239002-373a582a-d2dc-11e7-9d3d-88969a8d4f85.png) ![after](https://user-images.githubusercontent.com/1800018/33239001-37194c70-d2dc-11e7-9533-1b7eaf07e5ac.png)
