### PR TITLE
Update opn and fix 'favicon-emoji -l'

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@ const path = require('path')
 const emojilib = require('emojilib')
 const neodoc = require('neodoc')
 const toIco = require('to-ico')
+const open = require('open')
 
 const render = require('./lib/render')
 
@@ -41,9 +42,10 @@ Options:
 const args = neodoc.run(usage)
 
 if (args['--list']) {
-  require('opn')('https://www.webpagefx.com/tools/emoji-cheat-sheet/')
-  console.log('🕸 Opened emoji cheat sheet in browser')
-  process.exit(0)
+  console.log('🕸 Opening emoji cheat sheet in browser')
+  open('https://www.webpagefx.com/tools/emoji-cheat-sheet/').then(() => {
+    process.exit(0)
+  })
 }
 
 if (args['--emoji'] && args['--destination']) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "data-uri-to-buffer": "^2.0.0",
     "emojilib": "^2.2.9",
     "neodoc": "^1.4.0",
-    "opn": "^4.0.2",
+    "open": "^7.3.0",
     "puppeteer": "^1.3.0",
     "to-ico": "^1.1.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -904,6 +904,11 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
+is-docker@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
+  integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -966,6 +971,13 @@ is-symbol@^1.0.1:
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -1202,6 +1214,14 @@ once@^1.3.0:
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+open@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.3.0.tgz#45461fdee46444f3645b6e14eb3ca94b82e1be69"
+  integrity sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
 
 opn@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Hey @albinekb :wave: 

`opn` was renamed to `open`, and the exported function is async.
Closes #16.

- https://www.npmjs.com/package/opn